### PR TITLE
switch nonce from numerical date to uuidv4 string

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ var tmpdir = require('os').tmpdir();
 var path = require('path');
 var mime = require('mime');
 var async = require('async');
+var uuid = require('node-uuid');
 
 /**
  * Exposes a Storj Bridge API client
@@ -367,7 +368,7 @@ Client.prototype._request = function(method, path, params, stream) {
     method: method
   };
 
-  params.__nonce = Date.now();
+  params.__nonce = uuid.v4();
 
   if (['GET', 'DELETE'].indexOf(method) !== -1) {
     opts.qs = params;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "commander": "^2.9.0",
     "elliptic": "^6.2.3",
     "mime": "^1.3.4",
+    "node-uuid": "^1.4.7",
     "prompt": "^1.0.0",
     "request": "^2.67.0",
     "storj": "^0.6.16",


### PR DESCRIPTION
Re: https://github.com/Storj/bridge-client-javascript/issues/18

Bridge has been updated to switch from an incremental nonce to a unique nonce string. After that is deployed, it will be safe to merge this for the client.
